### PR TITLE
Restore visible focus on four controls and honour reduced motion

### DIFF
--- a/app/(docs)/components/_components/browse/component-preview-card.tsx
+++ b/app/(docs)/components/_components/browse/component-preview-card.tsx
@@ -68,7 +68,7 @@ export function ComponentPreviewCard({
           <h3 className="min-w-0 flex-1 truncate font-sans text-[15px] leading-snug">
             <SaveScrollLink
               href={`/components/${slug}`}
-              className="transition-colors outline-none hover:text-neutral-700"
+              className="transition-colors outline-none hover:text-neutral-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
             >
               <span className="font-semibold text-neutral-900">{title}</span>
               {isNew ? <ShowcaseNewBadge className="ml-1.5" /> : null}

--- a/app/(docs)/components/_components/shell/docs-sponsor-card.tsx
+++ b/app/(docs)/components/_components/shell/docs-sponsor-card.tsx
@@ -10,7 +10,7 @@ export function DocsSponsorCard() {
       <ContactEmailTrigger
         title="Become a sponsor"
         description="Feel free to copy my email and send over your brand details. I’ll share the sponsorship details with you."
-        className="group block w-full rounded-lg border-2 border-neutral-900 bg-neutral-900 p-4 text-left text-white outline-none transition-colors hover:border-neutral-800 hover:bg-neutral-800"
+        className="group block w-full rounded-lg border-2 border-neutral-900 bg-neutral-900 p-4 text-left text-white outline-none transition-colors hover:border-neutral-800 hover:bg-neutral-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
       >
         <div className="flex items-center justify-between gap-2">
           <span className="font-mono text-[10px] tracking-[0.14em] text-neutral-400 uppercase">

--- a/components/inputs/switch-field-input.tsx
+++ b/components/inputs/switch-field-input.tsx
@@ -150,7 +150,7 @@ export const SwitchFieldInput = forwardRef<
           }}
           onKeyDown={handleKeyDown}
           className={cn(
-            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 transition-[background-color,border-color] duration-200 outline-none ring-0 focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 transition-[background-color,border-color] duration-200 outline-none ring-0 focus:ring-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 disabled:cursor-not-allowed disabled:opacity-50",
             isOn
               ? "border-neutral-900 bg-neutral-900"
               : "border-neutral-200 bg-neutral-100",

--- a/components/wallet/wallet-pass-card.tsx
+++ b/components/wallet/wallet-pass-card.tsx
@@ -106,15 +106,15 @@ export const WalletPassCard = forwardRef<HTMLDivElement, WalletPassCardProps>(
           aria-label={flipped ? "Show pass front" : "Show pass back"}
           aria-pressed={flipped}
           data-slot="wallet-pass-card-flip"
-          className="relative h-54 w-full cursor-pointer overflow-hidden rounded-2xl border-0 bg-white p-0 shadow-lg outline-none"
-          style={{
-            animation: flipped
-              ? undefined
-              : "wallet-flip-shadow 3s ease-in-out infinite",
-          }}
+          className={cn(
+            "relative h-54 w-full cursor-pointer overflow-hidden rounded-2xl border-0 bg-white p-0 shadow-lg outline-none",
+            "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900",
+            !flipped &&
+              "animate-[wallet-flip-shadow_3s_ease-in-out_infinite] motion-reduce:animate-none",
+          )}
         >
           <div
-            className="relative h-full w-full transition-transform duration-700 ease-[cubic-bezier(0.34,1.2,0.64,1)]"
+            className="relative h-full w-full transition-transform duration-700 ease-[cubic-bezier(0.34,1.2,0.64,1)] motion-reduce:transition-none"
             style={{
               transformStyle: "preserve-3d",
               transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",


### PR DESCRIPTION
## Summary

Four elements set `outline-none` and never put a focus style back, so a keyboard user gets no indication of where they are:

| File | Element |
| --- | --- |
| `components/inputs/switch-field-input.tsx:153` | the `role="switch"` button |
| `components/wallet/wallet-pass-card.tsx:109` | the flip button |
| `app/(docs)/components/_components/browse/component-preview-card.tsx:71` | the card title link |
| `app/(docs)/components/_components/shell/docs-sponsor-card.tsx:13` | the sponsor card trigger |

The switch one is the worst of the four. It is wired for keyboard properly (`onKeyDown`, `aria-checked`, `aria-labelledby`), so someone can operate it without ever seeing which control they are on.

Each now uses the pattern that is already in 25 other files here:

```
focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900
```

No new convention, no `ring-*`, so the border-and-contrast focus rule in `design.md` still holds. On `docs-sponsor-card` the card is `bg-neutral-900`. `outline-offset-2` puts the outline on the white sidebar behind it, which is what the `bg-neutral-950` submit buttons in `components/forms/*` already do.

`wallet-pass-card` also ran a 3s infinite `box-shadow` keyframe through an inline `style` attribute. Nothing in a `motion-reduce:` class can reach an inline style, so a visitor who asked for reduced motion got the animation anyway. It moved to `animate-[wallet-flip-shadow_3s_ease-in-out_infinite]` with `motion-reduce:animate-none`. The flip transform picked up `motion-reduce:transition-none` to match `three-d-button.tsx:83`.

I checked the compiled CSS rather than assuming:

- `animation:3s ease-in-out infinite wallet-flip-shadow`, byte for byte the same declaration the inline style produced
- `.motion-reduce\:animate-none{animation:none}` sits inside `@media (prefers-reduced-motion:reduce)` and comes after the `animate-[...]` rule, so it wins at equal specificity

Not touched, on purpose: `journal-writing-card.tsx:94` also sets `outline-none`, on a `<textarea>`. A text caret is its own focus indicator there, so I left it rather than pad the diff.

## Type of change

- [ ] New component
- [x] Bug fix
- [ ] Docs / agent kit
- [ ] Site / marketing
- [ ] Chore (deps, CI, tooling)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (includes `check:showcase`)
- [ ] New components registered in `lib/showcase/showcase.tsx` (no new component)
- [ ] `skills/opensource-ui/references/source_inventory.txt` updated (if new file) (no new file)
- [x] Follows `.cursor/rules/component-design.mdc` (no purple, no `sm:`, self-contained files)

`npm run lint` reports the same 2 warnings as `main` (`DEFAULT_HANDLE_COLOR` unused in the two `components/frames/transform-*-frame.tsx` files). `npm run build` is green at 216 static pages. `npm run format:check` fails on 160 files on `main`, so I left formatting alone and only confirmed my edits do not change the prettier status of any file I touched.

## Screenshots (if UI change)

The visible change is a focus outline that only appears on keyboard focus, so a still frame does not show much. Easiest way to see it: `npm run dev`, open `/components`, then Tab through the grid and the sidebar sponsor card. On `main` the focus ring vanishes on the title links; here it tracks.

---

Written with AI assistance (Claude). Every claim above was checked against this repo rather than assumed: the 25-file count for the existing focus pattern, the compiled `animation` declaration, the media-query placement in the output CSS, then the prettier baseline. Local verification: `npm run lint`, `npm run typecheck` and `npm run build`.
