### PR TITLE
Drop the purple-family colours the design rules ban

### DIFF
--- a/app/(docs)/components/_components/browse/component-list-row.tsx
+++ b/app/(docs)/components/_components/browse/component-list-row.tsx
@@ -8,15 +8,15 @@ import { ShowcaseNewBadge } from "../shared/showcase-new-badge";
 
 const LETTER_COLORS = [
   { bg: "bg-neutral-100", text: "text-sky-700" },
-  { bg: "bg-neutral-100", text: "text-rose-600" },
+  { bg: "bg-neutral-100", text: "text-rose-700" },
   { bg: "bg-neutral-100", text: "text-amber-700" },
   { bg: "bg-neutral-100", text: "text-emerald-700" },
-  { bg: "bg-neutral-100", text: "text-violet-700" },
+  { bg: "bg-neutral-100", text: "text-teal-700" },
   { bg: "bg-neutral-100", text: "text-cyan-700" },
   { bg: "bg-neutral-100", text: "text-orange-700" },
   { bg: "bg-neutral-100", text: "text-fuchsia-700" },
   { bg: "bg-neutral-100", text: "text-lime-700" },
-  { bg: "bg-neutral-100", text: "text-indigo-700" },
+  { bg: "bg-neutral-100", text: "text-blue-700" },
 ] as const;
 
 function getLetterColor(index: number) {

--- a/components/underlines/annotated-text-showcase.tsx
+++ b/components/underlines/annotated-text-showcase.tsx
@@ -1,7 +1,7 @@
 import { AnnotatedText } from "@/components/underlines/annotated-text";
 
 const VARIANTS = [
-  { variant: "wavy", text: "Wavy underline", color: "text-purple-300" },
+  { variant: "wavy", text: "Wavy underline", color: "text-teal-300" },
   { variant: "circle", text: "Circled text", color: "text-cyan-200" },
   { variant: "highlight", text: "Highlighted text", color: "text-yellow-100" },
   { variant: "underline", text: "Simple underline", color: "text-cyan-200" },

--- a/components/underlines/annotated-text.tsx
+++ b/components/underlines/annotated-text.tsx
@@ -333,7 +333,7 @@ const annotationStyles = {
     Decoration: WavyDecoration,
     decorationClassName:
       "pointer-events-none absolute bottom-[-0.4em] left-[-2%] h-[0.7em] w-[104%]",
-    defaultColor: "text-purple-300",
+    defaultColor: "text-teal-300",
   },
   circle: {
     wrapper: "relative inline-block px-1 whitespace-nowrap",
@@ -354,7 +354,7 @@ const annotationStyles = {
     Decoration: UnderlineDecoration,
     decorationClassName:
       "pointer-events-none absolute bottom-[-0.32em] left-[-1%] h-[0.5em] w-[102%]",
-    defaultColor: "text-purple-400",
+    defaultColor: "text-emerald-400",
   },
   line: {
     wrapper: "relative inline-block whitespace-nowrap",

--- a/lib/docs/copy-code-block.tsx
+++ b/lib/docs/copy-code-block.tsx
@@ -117,7 +117,7 @@ function ImportLine({
     <p className="font-mono text-[13px] leading-6 break-all text-neutral-800">
       <span className="text-sky-700">import</span>
       <span> {"{ "}</span>
-      <span className="text-violet-700">{exportName}</span>
+      <span className="text-fuchsia-700">{exportName}</span>
       <span> {"}"} </span>
       <span className="text-sky-700">from</span>
       <span className="text-emerald-700"> &quot;{importPath}&quot;</span>
@@ -140,9 +140,9 @@ function UsageLine({ line }: Readonly<{ line: string }>) {
     const [, tag, attrs] = selfClosing;
     return (
       <span className="font-mono text-[13px] leading-7">
-        <span className="text-violet-700">&lt;{tag}</span>
-        <span className="text-amber-800">{attrs}</span>
-        <span className="text-violet-700"> /&gt;</span>
+        <span className="text-amber-700">&lt;{tag}</span>
+        <span className="text-yellow-700">{attrs}</span>
+        <span className="text-amber-700"> /&gt;</span>
       </span>
     );
   }
@@ -160,11 +160,11 @@ function UsageLine({ line }: Readonly<{ line: string }>) {
 
   return (
     <span className="font-mono text-[13px] leading-7">
-      <span className="text-violet-700">&lt;{tag}</span>
-      <span className="text-amber-800">{attrs}</span>
-      <span className="text-violet-700">&gt;</span>
+      <span className="text-amber-700">&lt;{tag}</span>
+      <span className="text-yellow-700">{attrs}</span>
+      <span className="text-amber-700">&gt;</span>
       <span className="text-neutral-800">{children}</span>
-      <span className="text-violet-700">&lt;/{tag}&gt;</span>
+      <span className="text-amber-700">&lt;/{tag}&gt;</span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary

`.cursor/rules/component-design.mdc:31` is blunt about it:

> **Banned:** `purple-*`, `violet-*`, `indigo-*` anywhere.

`skills/opensource-ui/references/design.md:211` says the same. Ten places still used them, including the docs chrome. This clears all of them except one deliberate case.

### `lib/docs/copy-code-block.tsx`

This file hand-rolls a light version of the code highlighter for the "How to use" block. It painted every JSX tag plus the imported export name `violet-700`.

Rather than pick a replacement by taste, I read the real highlighter sitting next to it. `lib/showcase/highlight-code.tsx` already has a token map at lines 69-80. Its tokeniser decides what each piece is:

| Piece | Tokeniser says | `TOKEN_CLASS` maps it to | New light value |
| --- | --- | --- | --- |
| `exportName` | `type`, because `/^[A-Z]/` wins at `highlight-code.tsx:145` | `fuchsia-400/90` | `text-fuchsia-700` |
| `<Tag>` | `jsx`, at `highlight-code.tsx:180` | `amber-400/90` | `text-amber-700` |
| attrs | `attr`, at `highlight-code.tsx:147` | `yellow-300/80` | `text-yellow-700` |

So the light snippet now uses the same token-to-hue map the dark panel already uses. Attrs had to move off `amber-800`, because tags landing on `amber-700` next to `amber-800` attrs would have been two shades of the same brown. Yellow for attrs is what the dark panel does anyway.

On `fuchsia`: it is not on the banned list. This repo already ships it in `highlight-code.tsx:73` plus `component-list-row.tsx:17`. Using it for `type` is matching your own existing choice for that exact token, not smuggling purple back in. Happy to go somewhere else if you read it differently.

### `app/(docs)/components/_components/browse/component-list-row.tsx`

The `LETTER_COLORS` array had `violet-700` at index 4 and `indigo-700` at index 9. Now `teal-700` and `blue-700`. `design.md:135` names teal as an accent the system wants. Neither hue collides with the eight already in the array.

While in that array: `rose-600` moved to `rose-700`. On the `bg-neutral-100` chip, `rose-600` measures **4.14:1**, under the 4.5 AA floor `design.md:208` asks for. It was the only entry of the ten that failed. The replacements measure `teal-700` 4.94, `blue-700` 6.26 then `rose-700` 5.55.

Those ratios are computed from the OKLCH values Tailwind v4 actually ships in `node_modules/tailwindcss/theme.css`, converted to sRGB, rather than from the old v3 hex table. The v3 table puts `rose-600` at 4.31, which fails too, so the conclusion is the same either way. I am quoting the v4 numbers because those are the colours this repo renders.

### `components/underlines/annotated-text.tsx`

Two `defaultColor` values: `purple-300` on `wavy` to `teal-300`, `purple-400` on `underline` to `emerald-400`. Both accents `design.md:135` lists. `annotated-text-showcase.tsx` follows so the showcase matches the default.

### Left alone on purpose

`components/socials/discord-chat-card.tsx:36` sets `roleColor: "text-violet-400"`. That is a Discord role colour on a card imitating Discord, so it reads as deliberate rather than an oversight. Say the word and it goes too.

## Type of change

- [ ] New component
- [ ] Bug fix
- [ ] Docs / agent kit
- [ ] Site / marketing
- [x] Chore (deps, CI, tooling)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (includes `check:showcase`)
- [ ] New components registered in `lib/showcase/showcase.tsx` (no new component)
- [ ] `skills/opensource-ui/references/source_inventory.txt` updated (if new file) (no new file)
- [x] Follows `.cursor/rules/component-design.mdc` (no purple, no `sm:`, self-contained files)

`npm run lint` gives the same 2 warnings as `main`. `npm run build` is green at 216 static pages. I grepped the built CSS afterwards: all eight new classes are emitted, all four old ones are gone.

`npm run format:check` fails on 160 files on `main`, so I did not run prettier over the tree. Two of the four files I touched were already failing before my change. They fail on exactly the same pre-existing lines afterwards.

## Screenshots (if UI change)

Two spots to look at with `npm run dev`:

- any component detail page, the "How to use" block under the preview. Import line and the JSX example.
- `/components` in list mode, the letter chips down the left of each row. Rows starting with the 5th and 10th letter position in the rotation.

---

Written with AI assistance (Claude). The token mapping above was read out of `highlight-code.tsx` rather than guessed, the contrast figures are WCAG 2.1 ratios computed from Tailwind v4's own OKLCH palette, then the before-and-after class lists were checked against the built CSS. Local verification: `npm run lint`, `npm run typecheck` and `npm run build`.
