### PR TITLE
Move the last 21 sm: utilities to md:

### DIFF
--- a/components/audio/now-playing-bar.tsx
+++ b/components/audio/now-playing-bar.tsx
@@ -99,7 +99,7 @@ export const NowPlayingBar = forwardRef<HTMLDivElement, NowPlayingBarProps>(
 
         <div
           data-slot="now-playing-bar-progress"
-          className="hidden h-1 w-16 overflow-hidden rounded-full bg-neutral-800 sm:block"
+          className="hidden h-1 w-16 overflow-hidden rounded-full bg-neutral-800 md:block"
         >
           <div
             className="h-full rounded-full bg-emerald-500"

--- a/components/gallery/film-strip-card.tsx
+++ b/components/gallery/film-strip-card.tsx
@@ -80,7 +80,7 @@ export const FilmStripCard = forwardRef<HTMLDivElement, FilmStripCardProps>(
           {frames.map((src, frameNumber) => (
             <div
               key={src}
-              className="relative h-20 w-16 shrink-0 overflow-hidden border-2 border-neutral-800 sm:h-24 sm:w-20"
+              className="relative h-20 w-16 shrink-0 overflow-hidden border-2 border-neutral-800 md:h-24 md:w-20"
             >
               <Image
                 src={src}

--- a/components/gallery/stamp-postcard-card.tsx
+++ b/components/gallery/stamp-postcard-card.tsx
@@ -35,7 +35,7 @@ export const StampPostcardCard = forwardRef<
       {...props}
     >
       <div className="relative overflow-hidden rounded-sm border border-neutral-200 bg-[#fffef8] shadow-md">
-        <div className="relative h-32 sm:h-36">
+        <div className="relative h-32 md:h-36">
           <Image
             src={imageSrc}
             alt={location}

--- a/components/others/terminal-log-card.tsx
+++ b/components/others/terminal-log-card.tsx
@@ -52,7 +52,7 @@ export const TerminalLogCard = forwardRef<HTMLDivElement, TerminalLogCardProps>(
       ref={ref}
       data-slot="terminal-log-card"
       className={cn(
-        "w-sm overflow-hidden rounded-xl border border-neutral-800 bg-[#0d0d0d] font-mono text-[11px] shadow-2xl shadow-black/40 sm:max-w-xs",
+        "w-sm overflow-hidden rounded-xl border border-neutral-800 bg-[#0d0d0d] font-mono text-[11px] shadow-2xl shadow-black/40 md:max-w-xs",
         className,
       )}
       {...props}

--- a/components/others/thermal-receipt-card.tsx
+++ b/components/others/thermal-receipt-card.tsx
@@ -52,7 +52,7 @@ export const ThermalReceiptCard = forwardRef<
     <div
       ref={ref}
       data-slot="thermal-receipt-card"
-      className={cn("w-55 font-mono sm:max-w-50", className)}
+      className={cn("w-55 font-mono md:max-w-50", className)}
       {...props}
     >
       <div className="relative bg-[#faf8f2] px-4 py-5 text-neutral-800 shadow-md">

--- a/components/text/cinema-ticket-card.tsx
+++ b/components/text/cinema-ticket-card.tsx
@@ -44,12 +44,12 @@ export const CinemaTicketCard = forwardRef<
       <div className="flex overflow-hidden rounded-2xl bg-neutral-950">
         <div
           data-slot="cinema-ticket-card-main"
-          className="min-w-0 flex-1 p-4 sm:p-5"
+          className="min-w-0 flex-1 p-4 md:p-5"
         >
           <p className="font-mono text-[9px] tracking-[0.25em] text-amber-500/70 uppercase">
             Admit one
           </p>
-          <h3 className="mt-1 truncate text-lg font-semibold tracking-tight text-white sm:text-xl">
+          <h3 className="mt-1 truncate text-lg font-semibold tracking-tight text-white md:text-xl">
             {filmTitle}
           </h3>
           <p className="mt-0.5 truncate text-xs text-neutral-500">{cinema}</p>

--- a/components/text/editorial-quote-card.tsx
+++ b/components/text/editorial-quote-card.tsx
@@ -47,7 +47,7 @@ export const EditorialQuoteCard = forwardRef<
         ref={ref}
         data-slot="editorial-quote-card"
         className={cn(
-          "w-sm border border-neutral-200 bg-[#f6f2eb] p-5 font-sans sm:p-6",
+          "w-sm border border-neutral-200 bg-[#f6f2eb] p-5 font-sans md:p-6",
           className,
         )}
         {...props}
@@ -64,7 +64,7 @@ export const EditorialQuoteCard = forwardRef<
 
         <blockquote
           data-slot="editorial-quote-card-quote"
-          className="text-lg leading-snug font-semibold tracking-tight text-neutral-700 sm:text-xl"
+          className="text-lg leading-snug font-semibold tracking-tight text-neutral-700 md:text-xl"
         >
           {segments.map(({ id, part }) =>
             part.toLowerCase() === accentWord.toLowerCase() ? (

--- a/components/text/keyboard-shortcuts-card.tsx
+++ b/components/text/keyboard-shortcuts-card.tsx
@@ -44,7 +44,7 @@ export const KeyboardShortcutsCard = forwardRef<
       ref={ref}
       data-slot="keyboard-shortcuts-card"
       className={cn(
-        "w-xs rounded-2xl border border-neutral-100 bg-white p-4 font-sans shadow-lg sm:p-5",
+        "w-xs rounded-2xl border border-neutral-100 bg-white p-4 font-sans shadow-lg md:p-5",
         className,
       )}
       {...props}

--- a/lib/showcase/highlight-code.tsx
+++ b/lib/showcase/highlight-code.tsx
@@ -306,10 +306,10 @@ export function HighlightedCode({ code }: Readonly<{ code: string }>) {
   const gutterWidth = String(lines.length).length;
 
   return (
-    <div className="flex min-w-0 font-mono text-xs leading-[1.65] tracking-tight select-none sm:min-w-max sm:text-[13px] sm:leading-[1.7]">
+    <div className="flex min-w-0 font-mono text-xs leading-[1.65] tracking-tight select-none md:min-w-max md:text-[13px] md:leading-[1.7]">
       <div
         aria-hidden
-        className="sticky left-0 hidden shrink-0 border-r border-neutral-700/60 bg-neutral-900 py-3 pr-2 pl-1.5 text-right text-neutral-600 tabular-nums select-none sm:block sm:py-4 sm:pr-3 sm:pl-2"
+        className="sticky left-0 hidden shrink-0 border-r border-neutral-700/60 bg-neutral-900 py-3 pr-2 pl-1.5 text-right text-neutral-600 tabular-nums select-none md:block md:py-4 md:pr-3 md:pl-2"
       >
         {lines.map(({ lineNumber, key }) => (
           <GutterLine
@@ -319,7 +319,7 @@ export function HighlightedCode({ code }: Readonly<{ code: string }>) {
           />
         ))}
       </div>
-      <code className="block min-w-0 py-3 pr-3 pl-3 sm:py-4 sm:pr-4 sm:pl-4">
+      <code className="block min-w-0 py-3 pr-3 pl-3 md:py-4 md:pr-4 md:pl-4">
         {lines.map(({ line, lineNumber, key }) => (
           <CodeLine key={key} line={line} lineNumber={lineNumber} />
         ))}


### PR DESCRIPTION
## Summary

`.cursor/rules/no-sm-breakpoints.mdc` is `alwaysApply: true` and says not to use `sm:` anywhere in the project, naming components, marketing then docs. Nine files still had it, 21 utilities in total. All of them are promoted to `md:`, which is what the rule's own before-and-after block shows.

| File | `sm:` utilities |
| --- | --- |
| `lib/showcase/highlight-code.tsx` | 10 |
| `components/gallery/film-strip-card.tsx` | 2 |
| `components/text/cinema-ticket-card.tsx` | 2 |
| `components/text/editorial-quote-card.tsx` | 2 |
| `components/audio/now-playing-bar.tsx` | 1 |
| `components/gallery/stamp-postcard-card.tsx` | 1 |
| `components/others/terminal-log-card.tsx` | 1 |
| `components/others/thermal-receipt-card.tsx` | 1 |
| `components/text/keyboard-shortcuts-card.tsx` | 1 |

Every one was the only responsive step on its property, so nothing had to be dropped. No file mixed `sm:` with `md:` on the same property, so this is a pure `sm:` to `md:` rename with no class removed.

What changes visibly: each step now fires at 768px instead of 640px. That is the point of a two-step system. Between those two widths those cards used to sit in a state the system does not define. The biggest one is the code panel in `highlight-code.tsx`, where the line-number gutter and the wider padding now appear at `md:`.

One thing worth flagging, because the job is not quite finished at the file level. After this change the built CSS still carries three `sm:` utilities:

```
.sm\:px-4   .sm\:w-80   .sm\:block
```

They come from the example markup in `no-sm-breakpoints.mdc:17-19`, because Tailwind v4 scans that file for class names. Grep the repo and those three strings exist nowhere else. Adding

```css
@source not "../.cursor/**";
```

to `app/globals.css` drops all three from the output. I verified that it works and then reverted it, because deciding what Tailwind scans is a project-wide call rather than part of this cleanup. Yours to make. Happy to push it into this PR if you want it.

## Type of change

- [ ] New component
- [ ] Bug fix
- [ ] Docs / agent kit
- [ ] Site / marketing
- [x] Chore (deps, CI, tooling)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (includes `check:showcase`)
- [ ] New components registered in `lib/showcase/showcase.tsx` (no new component)
- [ ] `skills/opensource-ui/references/source_inventory.txt` updated (if new file) (no new file)
- [x] Follows `.cursor/rules/component-design.mdc` (no purple, no `sm:`, self-contained files)

`grep -rn 'sm:[^ ]'` over `components/`, `app/` then `lib/` returns nothing after this change. That pattern is the one to use, since a plain `sm:` grep also matches the `sm:` size keys in the button variant maps, which are object properties rather than breakpoints.

`npm run lint` gives the same 2 warnings as `main`. `npm run build` is green at 216 static pages. Of the nine files, only `highlight-code.tsx` fails `format:check`. It failed the same way before this change.

## Screenshots (if UI change)

Nothing to show at a single width. To see it, run `npm run dev` and drag the window through 640px on a component detail page. On `main` the code panel gutter appears at 640px; here it appears at 768px, in step with the rest of the layout.

---

Written with AI assistance (Claude). Two things I checked rather than assumed. The rule file says `sm:` is "unreliable in this project's Tailwind v4 setup", which is not what I found: `sm:` compiles fine here, `min-width:40rem` is in the output CSS and the classes work. So the reason to remove them is the two-step design system, not breakage. Second, the three leftover classes above were traced to the rule file by grepping the whole repo. Local verification: `npm run lint`, `npm run typecheck` and `npm run build`.
