### PR TITLE
Fix the docs search shortcut hint and its modifier test

### DIFF
--- a/app/(docs)/components/_components/shell/docs-search.tsx
+++ b/app/(docs)/components/_components/shell/docs-search.tsx
@@ -54,6 +54,7 @@ export function DocsSearch() {
     getSearchShortcutLabel,
     () => "Control K",
   );
+  const isApple = shortcutLabel === "Command K";
   const [, startTransition] = useTransition();
 
   const applySearch = useCallback(
@@ -102,7 +103,12 @@ export function DocsSearch() {
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      // Exactly one of Cmd or Ctrl, and nothing else held, so Ctrl+Shift+K and
+      // Ctrl+Alt+K stay free for the browser and the OS.
+      const searchChord =
+        event.metaKey !== event.ctrlKey && !event.shiftKey && !event.altKey;
+
+      if (searchChord && event.key.toLowerCase() === "k") {
         event.preventDefault();
         inputRef.current?.focus();
         inputRef.current?.select();
@@ -147,14 +153,18 @@ export function DocsSearch() {
         autoComplete="off"
         autoCorrect="off"
         spellCheck={false}
-        className="w-full rounded-lg border border-neutral-100 bg-neutral-50/50 py-1.5 pr-3 pl-8 font-sans text-sm text-neutral-800 transition-colors outline-none placeholder:text-neutral-400 focus:border-rose-200 focus:bg-white md:pr-14"
+        className="w-full rounded-lg border border-neutral-100 bg-neutral-50/50 py-1.5 pr-3 pl-8 font-sans text-sm text-neutral-800 transition-colors outline-none placeholder:text-neutral-400 focus:border-rose-200 focus:bg-white md:pr-16"
       />
       <kbd
         aria-label={shortcutLabel}
         suppressHydrationWarning
         className="pointer-events-none absolute top-1/2 right-2.5 hidden -translate-y-1/2 items-center gap-0.5 rounded border border-neutral-100 bg-white px-1.5 py-0.5 font-mono text-[10px] text-neutral-400 md:inline-flex"
       >
-        <Command size={10} aria-hidden className="text-neutral-400" />
+        {isApple ? (
+          <Command size={10} aria-hidden className="text-neutral-400" />
+        ) : (
+          <span aria-hidden>Ctrl</span>
+        )}
         <span> + K</span>
       </kbd>
     </label>


### PR DESCRIPTION
## Summary

Two problems in `app/(docs)/components/_components/shell/docs-search.tsx`.

### The hint shows the wrong key off Apple

`getSearchShortcutLabel()` at line 24 already resolves the platform. The `kbd` `aria-label` at line 153 correctly reads "Control K" on Windows and Linux. The glyph next to it did not follow: line 157 rendered lucide's `Command` unconditionally, so a Windows user saw the Mac cloverleaf while a screen reader said Control.

The glyph now reads off the same value the label does, so there is one source of truth rather than a second platform sniff:

```tsx
const isApple = shortcutLabel === "Command K";
```

Non-Apple renders `Ctrl` as text. Input right padding moved from `md:pr-14` to `md:pr-16` so the longer hint clears the text area. At `text-[10px]` mono, `pr-14` was already about 2px short of clearing even the `Cmd` version.

### The chord test matched more than Cmd or Ctrl plus K

```tsx
if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
```

That matches any combination containing Cmd or Ctrl. `Ctrl+Shift+K` satisfied it. So did `Ctrl+Alt+K`. Both got `preventDefault()` plus a focus steal into the search field. Now:

```tsx
const searchChord =
  event.metaKey !== event.ctrlKey && !event.shiftKey && !event.altKey;
```

Exactly one of Cmd or Ctrl, nothing else held, so those chords go back to the browser and the OS. `Cmd+K` and `Ctrl+K` behave exactly as before.

### One thing that came up while checking

This component never server-renders in the static export. `useHydratedSearchParams` calls `useSearchParams`, so the `<Suspense fallback={null}>` around `DocsSearch` at `docs-header.tsx:39` is what gets prerendered. I confirmed it: the built `out/components.html` contains no `<kbd>` element at all. So the glyph is only ever chosen after hydration. This change cannot introduce a mismatch. The existing `suppressHydrationWarning` on the `kbd` is harmless either way.

## Type of change

- [ ] New component
- [x] Bug fix
- [ ] Docs / agent kit
- [ ] Site / marketing
- [ ] Chore (deps, CI, tooling)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (includes `check:showcase`)
- [ ] New components registered in `lib/showcase/showcase.tsx` (no new component)
- [ ] `skills/opensource-ui/references/source_inventory.txt` updated (if new file) (no new file)
- [x] Follows `.cursor/rules/component-design.mdc` (no purple, no `sm:`, self-contained files)

`npm run lint` gives the same 2 warnings as `main`. `npm run build` is green at 216 static pages. This file passes `format:check` both before this change as well as after, which is worth saying because 160 other files do not pass on `main`.

## Screenshots (if UI change)

`npm run dev` on a non-Mac, then look at the right edge of the docs search field at `md:` or wider. On `main` it reads `⌘ + K`; here it reads `Ctrl + K`. On a Mac nothing changes.

## Related

The dark mode work in a separate PR touches this same file, so whichever lands second will need a small rebase. Happy to do that.

---

Written with AI assistance (Claude). The prerender claim above is measured, not assumed: I grepped the built `out/components.html`. The 2px padding figure is arithmetic on `text-[10px]` mono advance width plus `px-1.5`, so treat it as approximate. Local verification: `npm run lint`, `npm run typecheck` and `npm run build`.
